### PR TITLE
add note about eslint and opening the correct folder

### DIFF
--- a/BJS/5 - Code Quality Tooling with Prettier and ESLint - 375475807.md
+++ b/BJS/5 - Code Quality Tooling with Prettier and ESLint - 375475807.md
@@ -1,1 +1,18 @@
 # Code Quality Tooling with Prettier and ESLint
+
+Please note that for ESLint to work you need to open the correct folder directly in your code editor, it will be the folder where you installed the `ESLint` npm packages and where you created the `.eslintrc` config file.
+
+Opening a parent folder or child folder in your code editor will cause ESLint to fail in finding the ESLint npm packages and the formatting won't work.
+
+```sh
+your-username
+  |
+  projects
+    |
+    beginner-javascript # <- Open this folder directly in your code editor
+      .eslintrc
+      package.json
+      node_modules/
+      exercises/
+      playground/
+```


### PR DESCRIPTION
Hey Wes,

I'll open a separate PR to the `eslint-config-wesbos` repo to add a similar note there as well.

A few people in the #beginner-javascript Slack channel have been running into an issue where ESLint either throws a `Parsing error: Cannot find module '@babel/preset-react` error or it just fails to format the code at all, so far each time the issue was caused by the person opening a parent `projects` or `code` folder and then manually navigating to the `beginner-javascript` folder in the file viewer on the side.

ESLint isn't happy unless the folder where it's installed is directly opened in VS Code. 🙂  