### PR TITLE
Add info about optional chaining availability

### DIFF
--- a/BJS/42 - Objects - 375651444.md
+++ b/BJS/42 - Objects - 375651444.md
@@ -1,1 +1,3 @@
 # Objects
+
+- Conditional Chaining is available on ES2020. Can view here [Optional chaining (?.) on MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining)


### PR DESCRIPTION
Optional chaining is available for use on recent browsers, I thought it was worth including some information 🙂