### PR TITLE
Leave note about issue in chrome for Image Gallery

### DIFF
--- a/GRID/20 - CSS Grid Image Gallery - 249560994.md
+++ b/GRID/20 - CSS Grid Image Gallery - 249560994.md
@@ -1,1 +1,3 @@
 # CSS Grid Image Gallery
+
+When one of the grid-column span values is larger than the grid-row span value, the image height in chrome is greater than 100%. This causes the "View" button to be pushed further down, out of vertical center. It is not an issue in firefox or chrome. Just be aware. As of now, there is no known fix.


### PR DESCRIPTION
Thank you for the free course! It's amazing, and I have to say, I didn't think there'd be this much content for it, but I've learned A TON!

Anyway, I was using chrome, and COULD NOT get the view button thing vertically centered. It ended up being because the image to fit inside the grid container when using chrome. It looks like it fits, but when you look at the devtools, you can see that it only looks like it fits because of `overflow: hidden`. I'm not sure what to do to fix it, I tried several things like setting max-height on the image, on the container, etc. I tried messing with overflow properties on all of the related elements, but nothing made a difference. I finally thought maybe it's not me and it's not just chrome and opened it up in Firefox and Safari to confirm that it was not me that had something wrong.

Thanks again for the course. I love it!