### PR TITLE
Fixed Typo "Unorderd" to correct spelling "Unordered"

### DIFF
--- a/MMD/6 - Lists — Ordered, Unorderd, Bullets and Nesting - 195944518.md
+++ b/MMD/6 - Lists — Ordered, Unorderd, Bullets and Nesting - 195944518.md
@@ -1,1 +1,1 @@
-# Lists — Ordered, Unorderd, Bullets and Nesting
+# Lists — Ordered, Unordered, Bullets and Nesting


### PR DESCRIPTION
- "Unorderd"
+ "Unordered"