### PR TITLE
Update 1 - JavaScript Drum Kit - 194130650.md

### DIFF
--- a/JS3/1 - JavaScript Drum Kit - 194130650.md
+++ b/JS3/1 - JavaScript Drum Kit - 194130650.md
@@ -1,1 +1,5 @@
 # JavaScript Drum Kit
+
+Hey Wes Bos, in your video, you don't remove the negation (!) before the == 'transform' line. This prevents the key from reverting back to its original border after the key press.
+
+It was driving me nuts (I'm in my third week of learning software engineering) and I couldn't really figure out why it wasn't working until a classmate brought it up (credits to @echo75 Johan Hedman)


### PR DESCRIPTION
Key border does not revert back to its original shape after key press due to negation (!) not being removed before == 'transform'