### PR TITLE
Update 23 - Speech Synthesis - 194128242.md

### DIFF
--- a/JS3/23 - Speech Synthesis - 194128242.md
+++ b/JS3/23 - Speech Synthesis - 194128242.md
@@ -1,1 +1,7 @@
 # Speech Synthesis
+
+# For this to work in Firefox (and all other browsers) the SpeechSynthesis.addEventListener should be replaced with             
+#            populateVoices();
+#            if (speechSynthesis.onvoiceschanged !== undefined) {
+#                speechSynthesis.onvoiceschanged = populateVoices;
+#            }


### PR DESCRIPTION
The current video doesn't work in Firefox, my proposed note will work in all browsers and keep Firefox users from thinking they have done something wrong. Firefox does not call the 'voiceschanged' event on every page load, only the first one.